### PR TITLE
StatBox: make url optional

### DIFF
--- a/src/lib/widgets/StatBox.js
+++ b/src/lib/widgets/StatBox.js
@@ -26,9 +26,10 @@ function StatBox({
       <div className="icon">
         <i className={iconClasses}></i>
       </div>
+      {url &&
       <a href={url} className="small-box-footer">
         {urlText} <i className="fa fa-arrow-circle-right"></i>
-      </a>
+      </a>}
     </div>
   );
 }


### PR DESCRIPTION
Do not render the link when URL is not set.

Signed-off-by: Vianney Bajart <vianney.bajart@gmail.com>